### PR TITLE
Use '_' instead of '.' in symbol name sanitization

### DIFF
--- a/src/librustc_codegen_utils/symbol_names.rs
+++ b/src/librustc_codegen_utils/symbol_names.rs
@@ -421,7 +421,7 @@ pub fn sanitize(result: &mut String, s: &str) -> bool {
 
             // '.' doesn't occur in types and functions, so reuse it
             // for ':' and '-'
-            '-' | ':' => result.push('.'),
+            '-' | ':' => result.push('_'),
 
             // These are legal symbols
             'a'...'z' | 'A'...'Z' | '0'...'9' | '_' | '.' | '$' => result.push(c),


### PR DESCRIPTION
As commended in the rustc code:

> Name sanitation. LLVM will happily accept identifiers with weird names, but gas doesn't!
> gas accepts the following characters in symbols: a-z, A-Z, 0-9, ., _, $

rustc sanitizes symbol name for [GAS](https://en.wikipedia.org/wiki/GNU_Assembler) output, but the rule of symbol names in PTX seems to be different from GAS especially around '.'. `sanitize` function in librustc_codegen_utils replace '-' and ':' into '.', but it causes problem as reported,
https://github.com/rust-lang/rust/issues/38789#issuecomment-409881625
and this changes it to '_'.